### PR TITLE
Add check and verify callsign

### DIFF
--- a/DA62checklists.json
+++ b/DA62checklists.json
@@ -257,6 +257,11 @@
               "response": "REQUEST"
             },
             {
+              "text": "Callsign",
+              "type": "Challenge",
+              "response": "CHECK"
+            },            
+            {
               "text": "Flight plan",
               "type": "Challenge",
               "response": "LOADED"
@@ -808,6 +813,11 @@
               "type": "Challenge",
               "response": "ALL OFF"
             },
+            {
+              "text": "Callsign",
+              "type": "Challenge",
+              "response": "RESET"
+            },            
             {
               "text": "Avionics",
               "type": "Challenge",


### PR DESCRIPTION
When using a custom callsign (angel flights and foreflight for PDC), checklist to set it and reset before shutdown back to the regular callsign.